### PR TITLE
Add --no-warmup option to mdr show

### DIFF
--- a/markdownreveal/commands.py
+++ b/markdownreveal/commands.py
@@ -61,7 +61,19 @@ def cli():
     default=None,
     help='Select a file as the warmup image (default: none).',
 )
-def show(markdown_file: Path, host: str = 'localhost', port: int = 8123, warmup: str = None):
+@click.option(
+    '-n',
+    '--no-warmup',
+    is_flag=True,
+    help='Ignore the warmup image, even if it exists (default: false).'
+)
+def show(
+        markdown_file: Path,
+        host: str = 'localhost',
+        port: int = 8123,
+        warmup: str = None,
+        no_warmup: bool = False,
+):
     """
     Visualize your presentation (default).
     """
@@ -69,7 +81,7 @@ def show(markdown_file: Path, host: str = 'localhost', port: int = 8123, warmup:
     config = load_config()
 
     # Initial generation
-    generate(markdown_file, warmup=warmup)
+    generate(markdown_file, warmup=warmup, no_warmup=no_warmup)
 
     observer = Observer()
     url = 'http://{host}:{port}'.format(host=host, port=port)

--- a/markdownreveal/commands.py
+++ b/markdownreveal/commands.py
@@ -55,15 +55,6 @@ def cli():
     help='Listen on port (default: 8123).',
 )
 @click.option(
-    '-w',
-    '--warmup',
-    type=str,
-    default=None,
-    help='Override the warmup image selected in the config.yaml file'
-         ' with another image having the specified name located'
-         ' inside the style folder.',
-)
-@click.option(
     '-n',
     '--no-warmup',
     is_flag=True,
@@ -74,7 +65,6 @@ def show(
         markdown_file: Path,
         host: str = 'localhost',
         port: int = 8123,
-        warmup: str = None,
         no_warmup: bool = False,
 ):
     """
@@ -84,7 +74,7 @@ def show(
     config = load_config()
 
     # Initial generation
-    generate(markdown_file, warmup=warmup, no_warmup=no_warmup)
+    generate(markdown_file, no_warmup=no_warmup)
 
     observer = Observer()
     url = 'http://{host}:{port}'.format(host=host, port=port)

--- a/markdownreveal/commands.py
+++ b/markdownreveal/commands.py
@@ -59,13 +59,13 @@ def cli():
     '--no-warmup',
     is_flag=True,
     help='Do not display the warmup slide, even if it exists in the'
-         ' style folder (default: false).'
+    ' style folder (default: false).',
 )
 def show(
-        markdown_file: Path,
-        host: str = 'localhost',
-        port: int = 8123,
-        no_warmup: bool = False,
+    markdown_file: Path,
+    host: str = 'localhost',
+    port: int = 8123,
+    no_warmup: bool = False,
 ):
     """
     Visualize your presentation (default).

--- a/markdownreveal/commands.py
+++ b/markdownreveal/commands.py
@@ -54,7 +54,14 @@ def cli():
     default=8123,
     help='Listen on port (default: 8123).',
 )
-def show(markdown_file: Path, host: str = 'localhost', port: int = 8123):
+@click.option(
+    '-w',
+    '--warmup',
+    type=str,
+    default=None,
+    help='Select a file as the warmup image (default: none).',
+)
+def show(markdown_file: Path, host: str = 'localhost', port: int = 8123, warmup: str = None):
     """
     Visualize your presentation (default).
     """
@@ -62,7 +69,7 @@ def show(markdown_file: Path, host: str = 'localhost', port: int = 8123):
     config = load_config()
 
     # Initial generation
-    generate(markdown_file)
+    generate(markdown_file, warmup=warmup)
 
     observer = Observer()
     url = 'http://{host}:{port}'.format(host=host, port=port)

--- a/markdownreveal/commands.py
+++ b/markdownreveal/commands.py
@@ -59,13 +59,16 @@ def cli():
     '--warmup',
     type=str,
     default=None,
-    help='Select a file as the warmup image (default: none).',
+    help='Override the warmup image selected in the config.yaml file'
+         ' with another image having the specified name located'
+         ' inside the style folder.',
 )
 @click.option(
     '-n',
     '--no-warmup',
     is_flag=True,
-    help='Ignore the warmup image, even if it exists (default: false).'
+    help='Do not display the warmup slide, even if it exists in the'
+         ' style folder (default: false).'
 )
 def show(
         markdown_file: Path,

--- a/markdownreveal/convert.py
+++ b/markdownreveal/convert.py
@@ -115,8 +115,7 @@ def generate(markdown_file, no_warmup=False):
     # If the --no-warmup option was specified, do not generate the warmup slide
     # The 'no_warmup' key in the config makes the tweak_html_warmup function
     # return None, skipping the slide generation
-    if no_warmup:
-        config['no_warmup'] = True
+    config['no_warmup'] = no_warmup
 
     # Initialize localdir
     initialize_localdir(config)

--- a/markdownreveal/convert.py
+++ b/markdownreveal/convert.py
@@ -105,12 +105,16 @@ def markdown_to_reveal(text: str, config: Config) -> str:
     return output
 
 
-def generate(markdown_file):
+def generate(markdown_file, warmup=None):
     """
     Generate Markdownreveal project.
     """
     # Reload config
     config = load_config()
+
+    # If the --warmup option was specified, edit the config setting for the warmup file
+    if warmup is not None:
+        config['style_warmup'] = warmup
 
     # Initialize localdir
     initialize_localdir(config)

--- a/markdownreveal/convert.py
+++ b/markdownreveal/convert.py
@@ -105,18 +105,16 @@ def markdown_to_reveal(text: str, config: Config) -> str:
     return output
 
 
-def generate(markdown_file, warmup=None, no_warmup=False):
+def generate(markdown_file, no_warmup=False):
     """
     Generate Markdownreveal project.
     """
     # Reload config
     config = load_config()
 
-    # If the --warmup option was specified, edit the config setting for the warmup file
-    if warmup is not None:
-        config['style_warmup'] = warmup
-
-    # If the --no-warmup option was specified, do not generate the warmup image
+    # If the --no-warmup option was specified, do not generate the warmup slide
+    # The 'no_warmup' key in the config makes the tweak_html_warmup function
+    # return None, skipping the slide generation
     if no_warmup:
         config['no_warmup'] = True
 

--- a/markdownreveal/convert.py
+++ b/markdownreveal/convert.py
@@ -105,7 +105,7 @@ def markdown_to_reveal(text: str, config: Config) -> str:
     return output
 
 
-def generate(markdown_file, warmup=None):
+def generate(markdown_file, warmup=None, no_warmup=False):
     """
     Generate Markdownreveal project.
     """
@@ -115,6 +115,10 @@ def generate(markdown_file, warmup=None):
     # If the --warmup option was specified, edit the config setting for the warmup file
     if warmup is not None:
         config['style_warmup'] = warmup
+
+    # If the --no-warmup option was specified, do not generate the warmup image
+    if no_warmup:
+        config['no_warmup'] = True
 
     # Initialize localdir
     initialize_localdir(config)

--- a/markdownreveal/tweak.py
+++ b/markdownreveal/tweak.py
@@ -60,7 +60,7 @@ def tweak_html_warmup(html, config):
     """
     TODO
     """
-    if 'no_warmup' in config and config['no_warmup']:
+    if config.get("no_warmup"):
         return
     fname = find_style_file('style_warmup', config)
     if not fname:

--- a/markdownreveal/tweak.py
+++ b/markdownreveal/tweak.py
@@ -60,6 +60,8 @@ def tweak_html_warmup(html, config):
     """
     TODO
     """
+    if 'no_warmup' in config and config['no_warmup']:
+        return
     fname = find_style_file('style_warmup', config)
     if not fname:
         return


### PR DESCRIPTION
`-w` or `--warmup` `FILENAME` allows the override of the warmup image specified in the `config.yaml` file.
`-n` or `--no-warmup` disables the warmup slide, even if the file specified in the config exists.

#8 