### PR TITLE
Initial Docker file. #6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM python:3.7-buster
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+ENV NODE_PATH                        /node_modules
+ENV PATH                             /node_modules/.bin:$PATH
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+        && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+        && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+        && apt-get update \
+        && apt-get install -y \
+        pandoc \
+        rsync \
+        nodejs \
+        google-chrome-unstable \
+        fonts-ipafont-gothic \
+        fonts-wqy-zenhei \
+        fonts-thai-tlwg \
+        fonts-kacst \
+        fonts-freefont-ttf \
+        --no-install-recommends \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN npm i puppeteer decktape \
+        # Add user so we don't need --no-sandbox.
+        # same layer as npm install to keep re-chowned files from using up several hundred MBs more space
+        && groupadd -r mdr && useradd -r -g mdr -G audio,video mdr \
+        && mkdir -p /home/mdr/files \
+        && chown -R mdr:mdr /home/mdr \
+        && chown -R mdr:mdr /node_modules
+
+WORKDIR /home/mdr/files
+
+COPY . /home/mdr/files
+
+RUN python -m pip install --upgrade pip \
+        && python -m pip install -r requirements.txt \
+        && python setup.py install \
+        && cd .. \
+        && rm -rf tmp/*
+
+USER mdr
+
+EXPOSE 8123
+
+ENTRYPOINT ["markdownreveal"]
+
+CMD ["presentation.md"]

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -39,6 +39,12 @@ Installation is very straight-forward:
 This will install all the required dependencies and will provide you with the
 ``markdownreveal`` command.
 
+Alternatively, you can use Docker for running ``markdownreveal`` command:
+
+.. code-block:: bash
+
+   docker run -it --rm -p 8123:8123 -v ${PWD}/tmp:/home/mdr/files markdownreveal/markdownreveal -p 8123 -h 0.0.0.0 presentation.md
+
 
 .. index:: first steps
 


### PR DESCRIPTION
Hi @Peque,

I told you that I plan to use Alpine instead of Debian before, but pandoc seems not available in the repositories. So the dependencies are like:

![pandoc](https://user-images.githubusercontent.com/72323/66166535-df922f00-e637-11e9-8402-c4bf07ec64ac.jpeg)

I tested to run the web server and seems well, but I can't say the same thing for dectape. I installed all the required dependencies, including google-chrome and puppeteer, but it needs some parameters, for example:

```
decktape --chrome-path=$(which google-chrome) --chrome-arg="--no-sandbox" https://google.com /home/mdr/files/test.pdf
```

Any idea about that? Can we inject some parameters to decktape for using it in Docker?